### PR TITLE
correct maintainer surname spelling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Local Indicator of Stratified Power
 Version: 0.2.0
 Authors@R: 
     c(
-      person(given = "Wenbo", family = "Lv",
+      person(given = "Wenbo", family = "Lyu",
              email = "lyu.geosocial@gmail.com", 
              role = c("aut", "cre", "cph"),
              comment = c(ORCID = "0009-0002-6003-3800")),

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -22,7 +22,7 @@ home:
 authors:
   Jiao Hu:
     href: https://www.researchgate.net/profile/Jiao-Hu-8
-  Wenbo Lv:
+  Wenbo Lyu:
     href: https://spatlyu.github.io/
   Yongze Song:
     href: https://yongzesong.com/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -20,12 +20,12 @@ home:
   title: |
     localsp | Local Indicator of Stratified Power
 authors:
-  Jiao Hu:
-    href: https://www.researchgate.net/profile/Jiao-Hu-8
   Wenbo Lyu:
     href: https://spatlyu.github.io/
   Yongze Song:
     href: https://yongzesong.com/
+  Jiao Hu:
+    href: https://www.researchgate.net/profile/Jiao-Hu-8
 
 reference:
 - title: Local Indicator of Stratified Power (LISP)


### PR DESCRIPTION
This PR updates the maintainer name from `Wenbo Lv` to `Wenbo Lyu` to align with my official passport spelling.

## Background

- **Chinese name**: 吕文博
- **Previous English name**: Wenbo Lv
- **Passport spelling**: Wenbo Lyu

The spelling `Lyu` is the standardized ASCII representation of the surname "吕" (Lü) used in official Chinese documents, including passports. This change ensures consistency across all official and academic records.

## Changes

- Updated maintainer name in `DESCRIPTION` file
- Updated author information in package metadata